### PR TITLE
feat(docs): remove forceful issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Security Vulnerability
-    url: https://github.com/hoangsonww/WealthWise-Personal-Finance-App/security/advisories/new
-    about: Please report security vulnerabilities privately via GitHub Security Advisories — do not open a public issue.


### PR DESCRIPTION
This pull request makes a small change to the GitHub issue template configuration by removing the contact link for reporting security vulnerabilities. This simplifies the issue reporting process and disables blank issues.